### PR TITLE
Update SpotPage_postspot.php

### DIFF
--- a/lib/page/SpotPage_postspot.php
+++ b/lib/page/SpotPage_postspot.php
@@ -1,5 +1,5 @@
 <?php
-
+error_reporting(0);
 class SpotPage_postspot extends SpotPage_Abs {
 	private $_spotForm;
 	


### PR DESCRIPTION
Fix for bug: #46

Turning of the error reporting suppresses the warning resulting in a valid Json so the form get's properly clearded.
Since the spot's did get posted anyway the warning can be ignored.